### PR TITLE
Modernize for Homebridge v2.0 compatibility

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean install of node dependencies and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
@@ -16,13 +16,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 22
       - run: npm ci
       - run: npm test
 
@@ -22,10 +22,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [2.0.0] - 2026-04-21
+
+### Breaking Changes
+- Requires Node.js 18.15.0 or later (was `>=0.12.0`)
+- Requires Homebridge 1.8.0 or later (was `>=0.4.16`)
+
+### Changed
+- Added Homebridge v2.0 compatibility (`^1.8.0 || ^2.0.0-beta.0`)
+- Replaced deprecated `request` library with `axios` + `tough-cookie`
+- Replaced `q` promise library with native Promises
+- Removed unused `lodash` dependency
+- Fixed `Characteristic.getValue()` (removed in HB v2) — now uses `updateValue()`
+- Fixed double-callback bug in `setState`
+- Fixed `getName` callback signature
+- Fixed `updateStatus` to use correct `latestData` path
+- Updated GitHub Actions workflows to Node.js 18/20/22 and actions/checkout@v4
+- Added `config.schema.json` for Homebridge UI configuration support
+
+## [1.0.1]
+
+- Fork of [hacctarr/homebridge-tcc-fan](https://github.com/hacctarr/homebridge-tcc-fan)
+- Added `showFanControl`, `showAuto`, `showOn`, `showCirculate`, `showFollowSchedule` config options

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# homebridge-tcc-fan-plus
+
+Homebridge platform plugin for controlling Honeywell Total Connect Comfort (TCC) thermostat fan modes. Exposes all four fan modes as stateful HomeKit switches.
+
+## Project structure
+
+```
+index.js          Platform + accessory logic (Homebridge API)
+lib/tcc.js        TCC HTTP client (login, CheckDataSession, setFanSwitch)
+config.schema.json Homebridge UI config form schema
+```
+
+## Fan modes
+
+| TCC value | Mode            | HomeKit switch |
+|-----------|-----------------|----------------|
+| 0         | Auto            | Auto           |
+| 1         | On              | On             |
+| 2         | Circulate       | Circulate      |
+| 3         | Follow Schedule | Follow Schedule |
+
+Four stateful switches are shown in HomeKit — exactly one is on at a time. Tapping a switch activates that mode and the others flip off automatically. Tapping the active switch off falls back to Auto.
+
+## TCC API — important quirks
+
+**Login (`lib/tcc.js` `login()`):**
+- Must extract `__RequestVerificationToken` (ASP.NET CSRF) from the login page HTML and include it in the POST body
+- Several cookies must be pre-seeded in the jar before the first request — they are normally set by JavaScript and the server uses them for bot detection:
+  - `checkCookie=checkValue`
+  - `cmapi_cookie_privacy`, `notice_gdpr_prefs`, `notice_preferences`, `notice_behavior`
+- After a successful POST the server redirects to the dashboard — check that the response did NOT land back on the login page (which would mean bad credentials)
+
+**`SubmitControlScreenChanges` (fan mode POST):**
+- Returns a 302 redirect to `/portal/Device/Control/{deviceId}` after accepting the command — do NOT follow the redirect (`maxRedirects: 0`). The POST itself is the command; following the redirect causes a 30s hang.
+- Reuse the existing `session` object for commands. Only re-login as a fallback if the request fails.
+- All timeouts are 30s — the site is slow.
+
+## Deployment (Raspberry Pi via hb-service)
+
+Node and npm are at `/opt/homebridge/bin/` — NOT on the system PATH.
+
+```sh
+# Install from GitHub branch
+cd /var/lib/homebridge
+sudo PATH=/opt/homebridge/bin:$PATH /opt/homebridge/bin/npm install github:Freddicus/homebridge-tcc-fan#modernize
+
+# Install from npm (after publishing)
+sudo PATH=/opt/homebridge/bin:$PATH /opt/homebridge/bin/npm install homebridge-tcc-fan-plus
+
+# Restart
+sudo systemctl restart homebridge.service
+
+# Logs
+sudo journalctl -u homebridge.service -f
+```
+
+Plugins install to `/var/lib/homebridge/node_modules/` — installing with `-g` puts them in the wrong place.
+
+## Config reference
+
+```json
+{
+  "platform": "tcc-fan",
+  "name": "TCC Fan",
+  "username": "your@email.com",
+  "password": "yourpassword",
+  "refresh": 60,
+  "debug": false,
+  "showFanControl": false,
+  "showAuto": true,
+  "showOn": true,
+  "showCirculate": true,
+  "showFollowSchedule": true,
+  "devices": [
+    { "deviceID": "1811704", "name": "House Fan" }
+  ]
+}
+```
+
+`showFanControl` is a legacy on/off toggle (off by default). The four `show*` switches default to `true`.
+
+## Publishing
+
+Auto-publishes to npm when a GitHub Release is created (`.github/workflows/npm-publish.yml`). Requires an `npm_token` secret in the repo settings.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,65 @@
 # homebridge-tcc-fan-plus
 
-Forked from https://github.com/hacctarr/homebridge-tcc-fan
+Homebridge platform plugin for controlling the fan on Honeywell Total Connect Comfort (TCC) thermostats. Supports Homebridge v1.8+ and v2.0.
 
-See README there: https://github.com/hacctarr/homebridge-tcc-fan/blob/master/README.md
+Forked from [hacctarr/homebridge-tcc-fan](https://github.com/hacctarr/homebridge-tcc-fan) with additional fan mode switches.
 
-Install locally with: `sudo npm link`
+## Installation
 
-# New in this fork
+Install via the Homebridge UI, or manually:
 
-- showFanControl: Show traditional HomeKit fan control (On is On and Off is Auto)
-- showOn: Show a momentary switch for On fan mode.
-- showAuto: Show a momentary switch for Auto fan mode.
-- showCirculate: Show a momentary switch for Circulate fan mode.
-- showFollowSchedule: Show a momentary switch for Follow Schedule fan mode.
+```sh
+npm install -g homebridge-tcc-fan-plus
+```
 
-# Roadmap
+## Configuration
 
-- Make the On/Auto/Circulate/Follow Schedule switches stateful.
+Add a platform entry to your Homebridge `config.json`:
+
+```json
+{
+  "platform": "tcc-fan",
+  "name": "TCC Fan",
+  "username": "your@email.com",
+  "password": "yourpassword",
+  "refresh": 60,
+  "showFanControl": true,
+  "showAuto": false,
+  "showOn": false,
+  "showCirculate": false,
+  "showFollowSchedule": false,
+  "devices": [
+    { "deviceID": "123456789", "name": "Main Floor" },
+    { "deviceID": "987654321", "name": "Upper Floor" }
+  ]
+}
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `username` | string | required | TCC account email |
+| `password` | string | required | TCC account password |
+| `devices` | array | required | List of `{ deviceID, name }` objects |
+| `refresh` | integer | `60` | Seconds between state updates |
+| `debug` | boolean | `false` | Enable verbose logging |
+| `showFanControl` | boolean | `true` | Show main On/Off fan control (On = On, Off = Auto) |
+| `showAuto` | boolean | `false` | Show a momentary switch for Auto fan mode |
+| `showOn` | boolean | `false` | Show a momentary switch for On fan mode |
+| `showCirculate` | boolean | `false` | Show a momentary switch for Circulate fan mode |
+| `showFollowSchedule` | boolean | `false` | Show a momentary switch for Follow Schedule fan mode |
+
+### Fan Modes
+
+| TCC Mode | Value |
+|---|---|
+| Auto | 0 |
+| On | 1 |
+| Circulate | 2 |
+| Follow Schedule | 3 |
+
+## Requirements
+
+- Node.js 18.15.0 or later
+- Homebridge 1.8.0 or later (including v2.0)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,33 @@ Forked from [hacctarr/homebridge-tcc-fan](https://github.com/hacctarr/homebridge
 
 ## Installation
 
-Install via the Homebridge UI, or manually:
+Install via the Homebridge UI, or manually on the machine running Homebridge:
 
 ```sh
 npm install -g homebridge-tcc-fan-plus
+```
+
+> **Note for hb-service installs (Raspberry Pi, Linux):** Homebridge bundles its own Node.js and npm that are not on the system PATH. Use the bundled npm and install into the Homebridge storage directory instead:
+> ```sh
+> cd /var/lib/homebridge
+> sudo PATH=/opt/homebridge/bin:$PATH /opt/homebridge/bin/npm install homebridge-tcc-fan-plus
+> sudo systemctl restart homebridge.service
+> ```
+
+### Installing a local or pre-release version for testing
+
+If you are testing from a Git branch before publishing to npm:
+
+```sh
+cd /var/lib/homebridge
+sudo PATH=/opt/homebridge/bin:$PATH /opt/homebridge/bin/npm install github:Freddicus/homebridge-tcc-fan#modernize
+sudo systemctl restart homebridge.service
+```
+
+Watch the logs to confirm the plugin loaded:
+
+```sh
+sudo journalctl -u homebridge.service -f
 ```
 
 ## Configuration
@@ -23,11 +46,10 @@ Add a platform entry to your Homebridge `config.json`:
   "username": "your@email.com",
   "password": "yourpassword",
   "refresh": 60,
-  "showFanControl": true,
-  "showAuto": false,
-  "showOn": false,
-  "showCirculate": false,
-  "showFollowSchedule": false,
+  "showAuto": true,
+  "showOn": true,
+  "showCirculate": true,
+  "showFollowSchedule": true,
   "devices": [
     { "deviceID": "123456789", "name": "Main Floor" },
     { "deviceID": "987654321", "name": "Upper Floor" }
@@ -44,20 +66,22 @@ Add a platform entry to your Homebridge `config.json`:
 | `devices` | array | required | List of `{ deviceID, name }` objects |
 | `refresh` | integer | `60` | Seconds between state updates |
 | `debug` | boolean | `false` | Enable verbose logging |
-| `showFanControl` | boolean | `true` | Show main On/Off fan control (On = On, Off = Auto) |
-| `showAuto` | boolean | `false` | Show a momentary switch for Auto fan mode |
-| `showOn` | boolean | `false` | Show a momentary switch for On fan mode |
-| `showCirculate` | boolean | `false` | Show a momentary switch for Circulate fan mode |
-| `showFollowSchedule` | boolean | `false` | Show a momentary switch for Follow Schedule fan mode |
+| `showAuto` | boolean | `true` | Show Auto mode switch |
+| `showOn` | boolean | `true` | Show On mode switch |
+| `showCirculate` | boolean | `true` | Show Circulate mode switch |
+| `showFollowSchedule` | boolean | `true` | Show Follow Schedule mode switch |
+| `showFanControl` | boolean | `false` | Show legacy On/Off fan toggle (On = mode 1, Off = Auto) |
 
 ### Fan Modes
 
-| TCC Mode | Value |
-|---|---|
-| Auto | 0 |
-| On | 1 |
-| Circulate | 2 |
-| Follow Schedule | 3 |
+All four TCC fan modes are exposed as stateful HomeKit switches. Exactly one switch is on at a time, reflecting the current mode. Tapping a switch activates that mode; the others turn off automatically.
+
+| TCC Mode | Value | Switch |
+|---|---|---|
+| Auto | 0 | Auto |
+| On | 1 | On |
+| Circulate | 2 | Circulate |
+| Follow Schedule | 3 | Follow Schedule |
 
 ## Requirements
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,82 @@
+{
+  "pluginAlias": "tcc-fan",
+  "pluginType": "platform",
+  "singular": false,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "type": "string",
+        "default": "TCC Fan",
+        "required": true
+      },
+      "username": {
+        "title": "TCC Username / Email",
+        "type": "string",
+        "required": true
+      },
+      "password": {
+        "title": "TCC Password",
+        "type": "string",
+        "required": true
+      },
+      "refresh": {
+        "title": "Refresh Interval (seconds)",
+        "type": "integer",
+        "default": 60,
+        "minimum": 10
+      },
+      "debug": {
+        "title": "Enable Debug Logging",
+        "type": "boolean",
+        "default": false
+      },
+      "showFanControl": {
+        "title": "Show Fan On/Off Control",
+        "type": "boolean",
+        "default": true
+      },
+      "showAuto": {
+        "title": "Show Auto Mode Switch",
+        "type": "boolean",
+        "default": false
+      },
+      "showOn": {
+        "title": "Show On Mode Switch",
+        "type": "boolean",
+        "default": false
+      },
+      "showCirculate": {
+        "title": "Show Circulate Mode Switch",
+        "type": "boolean",
+        "default": false
+      },
+      "showFollowSchedule": {
+        "title": "Show Follow Schedule Mode Switch",
+        "type": "boolean",
+        "default": false
+      },
+      "devices": {
+        "title": "Devices",
+        "type": "array",
+        "required": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "deviceID": {
+              "title": "Device ID",
+              "type": "string",
+              "required": true
+            },
+            "name": {
+              "title": "Device Name",
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,29 +33,34 @@
         "default": false
       },
       "showFanControl": {
-        "title": "Show Fan On/Off Control",
+        "title": "Show Legacy On/Off Fan Toggle",
+        "description": "Simple on/off switch (On = mode 1, Off = Auto). Disabled by default in favour of the four mode switches below.",
         "type": "boolean",
-        "default": true
+        "default": false
       },
       "showAuto": {
         "title": "Show Auto Mode Switch",
+        "description": "Stateful switch — on when fan is in Auto mode.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "showOn": {
         "title": "Show On Mode Switch",
+        "description": "Stateful switch — on when fan is forced on.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "showCirculate": {
         "title": "Show Circulate Mode Switch",
+        "description": "Stateful switch — on when fan is in Circulate mode.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "showFollowSchedule": {
         "title": "Show Follow Schedule Mode Switch",
+        "description": "Stateful switch — on when fan is following its schedule.",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "devices": {
         "title": "Devices",

--- a/index.js
+++ b/index.js
@@ -1,47 +1,48 @@
 // This platform integrates Honeywell TCC's Fan into homebridge
-// As I only own single thermostat, so this only works with one, but it is
-// conceivable to handle mulitple with additional coding.
 //
-// The configuration is stored inside the ../config.json
+// Config example (in config.json):
 // {
-//     "platform": "tcc",
+//     "platform": "tcc-fan",
 //     "name":     "Fan",
 //     "username" : "username/email",
 //     "password" : "password",
-//     "debug" : "True",      - Optional
-//     "refresh": "60",       - Optional
+//     "debug" : false,            - Optional
+//     "refresh": 60,              - Optional, seconds between updates
+//     "showFanControl": true,     - Optional, show main fan On/Off (default: true)
+//     "showAuto": false,          - Optional, show Auto mode switch
+//     "showOn": false,            - Optional, show On mode switch
+//     "showCirculate": false,     - Optional, show Circulate mode switch
+//     "showFollowSchedule": false,- Optional, show Follow Schedule mode switch
 //     "devices" : [
 //        { "deviceID": "123456789", "name" : "Main Floor Thermostat" },
-//        { "deviceID": "123456789", "name" : "Upper Floor Thermostat" }
+//        { "deviceID": "987654321", "name" : "Upper Floor Thermostat" }
 //     ]
 // }
-//
 
 /*jslint node: true */
 'use strict';
 
-var tcc = require('./lib/tcc.js');
-var Accessory, Service, Characteristic, UUIDGen, CommunityTypes;
+const tcc = require('./lib/tcc.js');
 
-var myAccessories = [];
-var session; // reuse the same login session
-var updating; // Only one change at a time!!!!
+let Accessory, Service, Characteristic, UUIDGen;
+
+let myAccessories = [];
+let session;
+let updating = false;
 
 module.exports = function(homebridge) {
-
     Accessory = homebridge.platformAccessory;
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     UUIDGen = homebridge.hap.uuid;
 
-    homebridge.registerPlatform("homebridge-tcc-fan", "tcc-fan", tccPlatform);
-}
+    homebridge.registerPlatform('homebridge-tcc-fan', 'tcc-fan', tccPlatform);
+};
 
 function tccPlatform(log, config, api) {
-
     this.username = config['username'];
     this.password = config['password'];
-    this.refresh = config['refresh'] || 60; // Update every minute
+    this.refresh = config['refresh'] || 60;
     this.debug = config['debug'] || false;
     this.log = log;
     this.devices = config['devices'];
@@ -51,131 +52,103 @@ function tccPlatform(log, config, api) {
     this.showOn = config['showOn'] || false;
     this.showCirculate = config['showCirculate'] || false;
     this.showFollowSchedule = config['showFollowSchedule'] || false;
-
-    updating = false;
 }
 
 tccPlatform.prototype = {
     accessories: function(callback) {
-        this.log("Logging into tcc...");
-        var that = this;
+        this.log('Logging into tcc...');
+        const that = this;
 
         tcc.setCharacteristic(Characteristic);
         tcc.setDebug(this.debug);
 
         tcc.login(that.username, that.password).then(function(login) {
-            this.log("Logged into tcc!", this.devices);
+            that.log('Logged into tcc!', that.devices);
             session = login;
 
-            let requests = this.devices.map((device) => {
-                return new Promise((resolve) => {
-
-                    session.CheckDataSession(device.deviceID,
-                        function(err, deviceData) {
-                            if (err) {
-                                that.log("Create Device Error", err);
-                                resolve();
-                            } else {
-
-                                var newAccessory = new tccAccessory(that.log, device.name,
-                                    deviceData, that.username, that.password, device.deviceID, that.debug,
-                                    that.showFanControl, that.showAuto, that.showOn, that.showCirculate, that.showFollowSchedule);
-                                // store accessory in myAccessories
-                                myAccessories.push(newAccessory);
-                                resolve();
-                            }
-                        });
+            const requests = that.devices.map(device => {
+                return new Promise(resolve => {
+                    session.CheckDataSession(device.deviceID, function(err, deviceData) {
+                        if (err) {
+                            that.log('Create Device Error', err);
+                            resolve();
+                        } else {
+                            const newAccessory = new tccAccessory(
+                                that.log, device.name, deviceData,
+                                that.username, that.password, device.deviceID, that.debug,
+                                that.showFanControl, that.showAuto, that.showOn,
+                                that.showCirculate, that.showFollowSchedule
+                            );
+                            myAccessories.push(newAccessory);
+                            resolve();
+                        }
+                    });
                 });
-            })
-
-            // Need to wait for all devices to be configured
-
-            Promise.all(requests).then(() => {
-                callback(myAccessories);
-                that.periodicUpdate();
-                setInterval(that.periodicUpdate.bind(this), this.refresh * 1000);
-
             });
 
-            // End of login section
-        }.bind(this)).fail(function(err) {
-            // tell me if login did not work!
-            that.log("Error during Login:", err);
+            return Promise.all(requests).then(() => {
+                callback(myAccessories);
+                that.periodicUpdate();
+                setInterval(that.periodicUpdate.bind(that), that.refresh * 1000);
+            });
+        }).catch(function(err) {
+            that.log('Error during Login:', err);
             callback(err);
         });
     }
 };
 
 function updateStatus(that, service, data) {
-    // var that = this;
-    // if (that.device.latestData.hasFan && that.device.latestData.fanData && that.device.latestData.fanData.fanModeOnAllowed) {
-    if (data.hasFan && data.fanData && data.fanData.fanModeOnAllowed) {
-        service.getCharacteristic(Characteristic.On).getValue();
+    const latestData = data && data.latestData;
+    if (latestData && latestData.hasFan && latestData.fanData && latestData.fanData.fanModeOnAllowed) {
+        const value = tcc.toHomeBridgeFanSystem(latestData.fanData.fanMode);
+        service.getCharacteristic(Characteristic.On).updateValue(value);
     }
-
-
 }
 
-tccPlatform.prototype.periodicUpdate = function(t) {
-    if (this.debug) this.log("periodicUpdate");
-    var t = updateValues(this);
-}
+tccPlatform.prototype.periodicUpdate = function() {
+    if (this.debug) this.log('periodicUpdate');
+    updateValues(this);
+};
 
 function updateValues(that) {
-    if (that.debug) that.log("updateValues", myAccessories.length);
-    myAccessories.forEach(function(accessory) {
+    if (that.debug) that.log('updateValues', myAccessories.length);
 
+    myAccessories.forEach(function(accessory) {
         session.CheckDataSession(accessory.deviceID, function(err, deviceData) {
             if (err) {
-                that.log("ERROR: UpdateValues", accessory.name, err);
-                that.log("updateValues: Device not reachable", accessory.name);
-                // TODO replace for 1.x accessory.newAccessory.updateReachability(false);
+                that.log('ERROR: UpdateValues', accessory.name, err);
                 tcc.login(that.username, that.password).then(function(login) {
-                    that.log("Logged into tcc!");
+                    that.log('Re-logged into tcc after error');
                     session = login;
-                }.bind(this)).fail(function(err) {
-                    // tell me if login did not work!
-                    that.log("Error during Login:", err);
+                }).catch(function(loginErr) {
+                    that.log('Error during re-login:', loginErr);
                 });
             } else {
-                if (that.debug) that.log("Update Values", accessory.name, deviceData);
-                // Data is live
-
-                if (deviceData.deviceLive) {
-                    if (that.debug) that.log("updateValues: Device reachable", accessory.name);
-                    // TODO replace for 1.x accessory.newAccessory.updateReachability(true);
-                } else {
-                    if (that.debug) that.log("updateValues: Device not reachable", accessory.name);
-                    // TODO replace for 1.x accessory.newAccessory.updateReachability(false);
-                }
+                if (that.debug) that.log('Update Values', accessory.name, deviceData);
 
                 if (accessory.fanService && !tcc.deepEquals(deviceData, accessory.device)) {
-                    if (that.debug) that.log("Change", accessory.name, tcc.diff(accessory.device, deviceData));
+                    if (that.debug) that.log('Change', accessory.name, tcc.diff(accessory.device, deviceData));
                     accessory.device = deviceData;
                     updateStatus(that, accessory.fanService, deviceData);
                 } else {
-                    if (that.debug) that.log("No change", accessory.name);
+                    if (that.debug) that.log('No change', accessory.name);
                 }
             }
         });
     });
 }
 
-// give this function all the parameters needed
+function tccAccessory(log, name, deviceData, username, password, deviceID, debug,
+    showFanControl, showAuto, showOn, showCirculate, showFollowSchedule) {
 
-function tccAccessory(log, name, deviceData, username, password, deviceID, debug, showFanControl, showAuto, showOn, showCirculate, showFollowSchedule) {
-
-    var uuid = UUIDGen.generate(name);
-
+    const uuid = UUIDGen.generate(name);
     this.newAccessory = new Accessory(name, uuid);
 
-    //    newAccessory.name = name;
-
     this.log = log;
-    this.log("Adding TCC Device", name, deviceID);
+    this.log('Adding TCC Device', name, deviceID);
     this.name = name;
     this.device = deviceData;
-    this.device.deviceLive = "false";
     this.username = username;
     this.password = password;
     this.deviceID = deviceID;
@@ -185,213 +158,167 @@ function tccAccessory(log, name, deviceData, username, password, deviceID, debug
     this.showOn = showOn;
     this.showCirculate = showCirculate;
     this.showFollowSchedule = showFollowSchedule;
-
-    //    return newAccessory;
 }
 
 tccAccessory.prototype = {
 
     getName: function(callback) {
-        var that = this;
-        that.log("requesting name of", this.name);
-        callback(this.name);
+        this.log('requesting name of', this.name);
+        callback(null, this.name);
     },
 
     setState: function(value, callback) {
-        var that = this;
-        if (!updating) {
-            updating = true;
-
-            that.log("Setting fan switch for", this.name, "to", value);
-            // TODO:
-            // verify that the task did succeed
-
-            tcc.login(this.username, this.password).then(function(session) {
-                session.setFanSwitch(that.deviceID, value).then(function(taskId) {
-                    that.log("Successfully changed system!");
-                    that.log(taskId);
-                    // Update all information
-                    // TODO: call periodicUpdate to refresh all data elements
-                    updateValues(that);
-                    callback(null, Number(1));
-                });
-            }).fail(function(err) {
-                that.log('tcc Failed:', err);
-                callback(null, Number(0));
-            });
-            callback(null, Number(0));
-            updating = false
+        const that = this;
+        if (updating) {
+            callback(null);
+            return;
         }
+        updating = true;
+
+        that.log('Setting fan switch for', this.name, 'to', value);
+
+        tcc.login(this.username, this.password).then(function(newSession) {
+            return newSession.setFanSwitch(that.deviceID, value);
+        }).then(function(taskId) {
+            that.log('Successfully changed system!', taskId);
+            updating = false;
+            updateValues(that);
+            callback(null);
+        }).catch(function(err) {
+            that.log('tcc Failed:', err);
+            updating = false;
+            callback(err);
+        });
     },
 
     getState: function(callback) {
-        var that = this;
-
-        // Homekit allowed values
-        //         Characteristic.TargetFanState.MANUAL = 0;
-        //         Characteristic.TargetFanState.AUTO = 1;
-
-        var TargetFanState = tcc.toHomeBridgeFanSystem(this.device.latestData.fanData.fanMode);
-
-        this.log("getTargetFanState is ", TargetFanState, this.name);
-
-        callback(null, Boolean(TargetFanState));
+        const latestData = this.device && this.device.latestData;
+        if (!latestData || !latestData.fanData) {
+            callback(null, false);
+            return;
+        }
+        const fanState = tcc.toHomeBridgeFanSystem(latestData.fanData.fanMode);
+        this.log('getState is', fanState, this.name);
+        callback(null, Boolean(fanState));
     },
 
     getServices: function() {
-        var that = this;
-        that.log("getServices", this.name);
+        const that = this;
+        that.log('getServices', this.name);
 
-        // Information Service
         const informationService = new Service.AccessoryInformation();
         informationService
-            .setCharacteristic(Characteristic.Identify, this.name)
-            .setCharacteristic(Characteristic.Manufacturer, "Honeywell")
-            .setCharacteristic(Characteristic.Model, this.model)
+            .setCharacteristic(Characteristic.Manufacturer, 'Honeywell')
+            .setCharacteristic(Characteristic.Model, this.model || 'TCC Thermostat')
             .setCharacteristic(Characteristic.Name, this.name)
-            .setCharacteristic(Characteristic.SerialNumber, this.deviceID); // need to stringify the this.serial
+            .setCharacteristic(Characteristic.SerialNumber, String(this.deviceID));
 
-        const returnServices = [];
+        const returnServices = [informationService];
 
-        // Fan Service
         if (this.showFanControl) {
-            this.log("Creating fan service...");
+            that.log('Creating fan service...');
             this.fanService = new Service.Fan(this.name);
             this.fanService
                 .getCharacteristic(Characteristic.Name)
                 .on('get', this.getName.bind(this));
-            this.log("Fan service created!")
+            that.log('Fan service created!');
         }
 
-        if (this.device.latestData.hasFan && this.device.latestData.fanData && this.device.latestData.fanData.fanModeOnAllowed) {
+        const latestData = this.device && this.device.latestData;
+        if (latestData && latestData.hasFan && latestData.fanData && latestData.fanData.fanModeOnAllowed) {
+
             if (this.showFanControl) {
-                this.log("Updating fan service...");
                 this.fanService
                     .getCharacteristic(Characteristic.On)
                     .on('get', this.getState.bind(this))
                     .on('set', this.setState.bind(this));
-                this.log("Fan service updated.")
+                returnServices.push(this.fanService);
             }
 
             if (this.showAuto) {
-                this.log("Creating switch for \'Auto\'...");
-                this.myMomemtarySwitchAuto = new Service.Switch("Auto", "mode-auto");
+                that.log('Creating switch for \'Auto\'...');
+                this.myMomemtarySwitchAuto = new Service.Switch('Auto', 'mode-auto');
                 this.myMomemtarySwitchAuto
                     .getCharacteristic(Characteristic.On)
-                    .on("get", (callback) => {
-                        callback(false)
-                    })
-                    .on("set", (s, callback) => {
+                    .on('get', callback => callback(null, false))
+                    .on('set', (s, callback) => {
                         if (s === true) {
-                            if (myAccessories && myAccessories[0]) {
-                                myAccessories[0].setState(0, callback);
-                            }
-                            // reset switch to off
-                            setTimeout(function() {
-                                this.myMomemtarySwitchAuto.setCharacteristic(Characteristic.On, false);
-                            }.bind(this), 500);
+                            this.setState(0, callback);
+                            setTimeout(() => {
+                                this.myMomemtarySwitchAuto.updateCharacteristic(Characteristic.On, false);
+                            }, 500);
                         } else {
-                            callback(null, s);
+                            callback(null);
                         }
                     });
-                this.log("\'Auto\' switch created!");
+                returnServices.push(this.myMomemtarySwitchAuto);
+                that.log('\'Auto\' switch created!');
             }
 
             if (this.showOn) {
-                this.log("Creating switch for \'On\'...");
-                this.myMomemtarySwitchOn = new Service.Switch("On", "mode-on");
+                that.log('Creating switch for \'On\'...');
+                this.myMomemtarySwitchOn = new Service.Switch('On', 'mode-on');
                 this.myMomemtarySwitchOn
                     .getCharacteristic(Characteristic.On)
-                    .on("get", (callback) => {
-                        callback(false)
-                    })
-                    .on("set", (s, callback) => {
+                    .on('get', callback => callback(null, false))
+                    .on('set', (s, callback) => {
                         if (s === true) {
-                            if (myAccessories && myAccessories[0]) {
-                                myAccessories[0].setState(1, callback);
-                            }
-                            // reset switch to off
-                            setTimeout(function() {
-                                this.myMomemtarySwitchOn.setCharacteristic(Characteristic.On, false);
-                            }.bind(this), 500);
+                            this.setState(1, callback);
+                            setTimeout(() => {
+                                this.myMomemtarySwitchOn.updateCharacteristic(Characteristic.On, false);
+                            }, 500);
                         } else {
-                            callback(null, s);
+                            callback(null);
                         }
                     });
-                this.log("\'On\' switch created!");
+                returnServices.push(this.myMomemtarySwitchOn);
+                that.log('\'On\' switch created!');
             }
 
             if (this.showCirculate) {
-                this.log("Creating switch for \'Circulate\'...");
-                this.myMomemtarySwitchCirculate = new Service.Switch("Circulate", "mode-circulate");
+                that.log('Creating switch for \'Circulate\'...');
+                this.myMomemtarySwitchCirculate = new Service.Switch('Circulate', 'mode-circulate');
                 this.myMomemtarySwitchCirculate
                     .getCharacteristic(Characteristic.On)
-                    .on("get", (callback) => {
-                        callback(false)
-                    })
-                    .on("set", (s, callback) => {
+                    .on('get', callback => callback(null, false))
+                    .on('set', (s, callback) => {
                         if (s === true) {
-                            if (myAccessories && myAccessories[0]) {
-                                myAccessories[0].setState(2, callback);
-                            }
-                            // reset switch to off
-                            setTimeout(function() {
-                                this.myMomemtarySwitchCirculate.setCharacteristic(Characteristic.On, false);
-                            }.bind(this), 500);
+                            this.setState(2, callback);
+                            setTimeout(() => {
+                                this.myMomemtarySwitchCirculate.updateCharacteristic(Characteristic.On, false);
+                            }, 500);
                         } else {
-                            callback(null, s);
+                            callback(null);
                         }
                     });
-                this.log("\'Circulate\' switch created!");
+                returnServices.push(this.myMomemtarySwitchCirculate);
+                that.log('\'Circulate\' switch created!');
             }
 
             if (this.showFollowSchedule) {
-                this.log("Creating switch for \'Follow Schedule\'...")
-                this.myMomemtarySwitchFollowSchedule = new Service.Switch("Follow Schedule", "mode-follow-schedule");
+                that.log('Creating switch for \'Follow Schedule\'...');
+                this.myMomemtarySwitchFollowSchedule = new Service.Switch('Follow Schedule', 'mode-follow-schedule');
                 this.myMomemtarySwitchFollowSchedule
                     .getCharacteristic(Characteristic.On)
-                    .on("get", (callback) => {
-                        callback(false)
-                    })
-                    .on("set", (s, callback) => {
+                    .on('get', callback => callback(null, false))
+                    .on('set', (s, callback) => {
                         if (s === true) {
-                            if (myAccessories && myAccessories[0]) {
-                                myAccessories[0].setState(3, callback);
-                            }
-                            // reset switch to off
-                            setTimeout(function() {
-                                this.myMomemtarySwitchFollowSchedule.setCharacteristic(Characteristic.On, false);
-                            }.bind(this), 500);
+                            this.setState(3, callback);
+                            setTimeout(() => {
+                                this.myMomemtarySwitchFollowSchedule.updateCharacteristic(Characteristic.On, false);
+                            }, 500);
                         } else {
-                            callback(null, s);
+                            callback(null);
                         }
                     });
-                this.log("\'Follow Schedule\' switch created!");
+                returnServices.push(this.myMomemtarySwitchFollowSchedule);
+                that.log('\'Follow Schedule\' switch created!');
             }
-        }
-
-        returnServices.push(informationService);
-
-        if (this.showFanControl) {
+        } else if (this.showFanControl && this.fanService) {
+            // Fan service exists but device doesn't report fan capability yet
             returnServices.push(this.fanService);
-        }
-
-        if (this.showOn && this.myMomemtarySwitchOn) {
-            returnServices.push(this.myMomemtarySwitchOn);
-        }
-
-        if (this.showAuto && this.myMomemtarySwitchAuto) {
-            returnServices.push(this.myMomemtarySwitchAuto);
-        }
-
-        if (this.showCirculate && this.myMomemtarySwitchCirculate) {
-            returnServices.push(this.myMomemtarySwitchCirculate);
-        }
-
-        if (this.showFollowSchedule && this.myMomemtarySwitchFollowSchedule) {
-            returnServices.push(this.myMomemtarySwitchFollowSchedule);
         }
 
         return returnServices;
     }
-}
+};

--- a/index.js
+++ b/index.js
@@ -268,6 +268,8 @@ tccAccessory.prototype.getServices = function() {
         if (!this[key]) return;
 
         const svc = new Service.Switch(name, subtype);
+        svc.setCharacteristic(Characteristic.Name, name);
+        svc.setCharacteristic(Characteristic.ConfiguredName, name);
 
         svc.getCharacteristic(Characteristic.On)
             .on('get', cb => cb(null, this.getCurrentMode() === mode))

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@
 //     "name":     "Fan",
 //     "username" : "username/email",
 //     "password" : "password",
-//     "debug" : false,            - Optional
-//     "refresh": 60,              - Optional, seconds between updates
-//     "showFanControl": true,     - Optional, show main fan On/Off (default: true)
-//     "showAuto": false,          - Optional, show Auto mode switch
-//     "showOn": false,            - Optional, show On mode switch
-//     "showCirculate": false,     - Optional, show Circulate mode switch
-//     "showFollowSchedule": false,- Optional, show Follow Schedule mode switch
+//     "debug" : false,              - Optional
+//     "refresh": 60,                - Optional, seconds between updates
+//     "showFanControl": false,      - Optional, legacy on/off toggle (default: false)
+//     "showAuto": true,             - Optional, show Auto mode switch (default: true)
+//     "showOn": true,               - Optional, show On mode switch (default: true)
+//     "showCirculate": true,        - Optional, show Circulate mode switch (default: true)
+//     "showFollowSchedule": true,   - Optional, show Follow Schedule mode switch (default: true)
 //     "devices" : [
 //        { "deviceID": "123456789", "name" : "Main Floor Thermostat" },
 //        { "deviceID": "987654321", "name" : "Upper Floor Thermostat" }
@@ -30,11 +30,17 @@ let myAccessories = [];
 let session;
 let updating = false;
 
+// Fan modes
+const MODE_AUTO            = 0;
+const MODE_ON              = 1;
+const MODE_CIRCULATE       = 2;
+const MODE_FOLLOW_SCHEDULE = 3;
+
 module.exports = function(homebridge) {
-    Accessory = homebridge.platformAccessory;
-    Service = homebridge.hap.Service;
+    Accessory      = homebridge.platformAccessory;
+    Service        = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
-    UUIDGen = homebridge.hap.uuid;
+    UUIDGen        = homebridge.hap.uuid;
 
     homebridge.registerPlatform('homebridge-tcc-fan', 'tcc-fan', tccPlatform);
 };
@@ -42,16 +48,19 @@ module.exports = function(homebridge) {
 function tccPlatform(log, config, api) {
     this.username = config['username'];
     this.password = config['password'];
-    this.refresh = config['refresh'] || 60;
-    this.debug = config['debug'] || false;
-    this.log = log;
-    this.devices = config['devices'];
+    this.refresh  = config['refresh'] || 60;
+    this.debug    = config['debug']   || false;
+    this.log      = log;
+    this.devices  = config['devices'];
 
-    this.showFanControl = config['showFanControl'] !== false;
-    this.showAuto = config['showAuto'] || false;
-    this.showOn = config['showOn'] || false;
-    this.showCirculate = config['showCirculate'] || false;
-    this.showFollowSchedule = config['showFollowSchedule'] || false;
+    // Legacy on/off fan toggle — off by default in favour of mode switches
+    this.showFanControl = config['showFanControl'] || false;
+
+    // Stateful mode switches — all on by default
+    this.showAuto           = config['showAuto']           !== false;
+    this.showOn             = config['showOn']             !== false;
+    this.showCirculate      = config['showCirculate']      !== false;
+    this.showFollowSchedule = config['showFollowSchedule'] !== false;
 }
 
 tccPlatform.prototype = {
@@ -98,12 +107,20 @@ tccPlatform.prototype = {
     }
 };
 
-function updateStatus(that, service, data) {
+function updateStatus(that, accessory, data) {
     const latestData = data && data.latestData;
-    if (latestData && latestData.hasFan && latestData.fanData && latestData.fanData.fanModeOnAllowed) {
-        const value = tcc.toHomeBridgeFanSystem(latestData.fanData.fanMode);
-        service.getCharacteristic(Characteristic.On).updateValue(value);
+    if (!latestData || !latestData.hasFan || !latestData.fanData || !latestData.fanData.fanModeOnAllowed) return;
+
+    const mode = latestData.fanData.fanMode;
+
+    // Update legacy on/off fan service
+    if (accessory.fanService) {
+        accessory.fanService.getCharacteristic(Characteristic.On)
+            .updateValue(tcc.toHomeBridgeFanSystem(mode));
     }
+
+    // Update all mode switches — exactly one will be on
+    accessory.updateAllSwitches(mode);
 }
 
 tccPlatform.prototype.periodicUpdate = function() {
@@ -127,10 +144,10 @@ function updateValues(that) {
             } else {
                 if (that.debug) that.log('Update Values', accessory.name, deviceData);
 
-                if (accessory.fanService && !tcc.deepEquals(deviceData, accessory.device)) {
+                if (!tcc.deepEquals(deviceData, accessory.device)) {
                     if (that.debug) that.log('Change', accessory.name, tcc.diff(accessory.device, deviceData));
                     accessory.device = deviceData;
-                    updateStatus(that, accessory.fanService, deviceData);
+                    updateStatus(that, accessory, deviceData);
                 } else {
                     if (that.debug) that.log('No change', accessory.name);
                 }
@@ -145,180 +162,133 @@ function tccAccessory(log, name, deviceData, username, password, deviceID, debug
     const uuid = UUIDGen.generate(name);
     this.newAccessory = new Accessory(name, uuid);
 
-    this.log = log;
-    this.log('Adding TCC Device', name, deviceID);
-    this.name = name;
-    this.device = deviceData;
+    this.log      = log;
+    this.name     = name;
+    this.device   = deviceData;
     this.username = username;
     this.password = password;
     this.deviceID = deviceID;
-    this.debug = debug;
-    this.showFanControl = showFanControl;
-    this.showAuto = showAuto;
-    this.showOn = showOn;
-    this.showCirculate = showCirculate;
+    this.debug    = debug;
+
+    this.showFanControl     = showFanControl;
+    this.showAuto           = showAuto;
+    this.showOn             = showOn;
+    this.showCirculate      = showCirculate;
     this.showFollowSchedule = showFollowSchedule;
+
+    // Map of mode number → Switch service, used for mutual exclusion updates
+    this.modeServices = {};
+
+    this.log('Adding TCC Device', name, deviceID);
 }
 
-tccAccessory.prototype = {
+tccAccessory.prototype.getCurrentMode = function() {
+    const fanData = this.device && this.device.latestData && this.device.latestData.fanData;
+    return fanData ? fanData.fanMode : MODE_AUTO;
+};
 
-    getName: function(callback) {
-        this.log('requesting name of', this.name);
-        callback(null, this.name);
-    },
-
-    setState: function(value, callback) {
-        const that = this;
-        if (updating) {
-            callback(null);
-            return;
-        }
-        updating = true;
-
-        that.log('Setting fan switch for', this.name, 'to', value);
-
-        tcc.login(this.username, this.password).then(function(newSession) {
-            return newSession.setFanSwitch(that.deviceID, value);
-        }).then(function(taskId) {
-            that.log('Successfully changed system!', taskId);
-            updating = false;
-            updateValues(that);
-            callback(null);
-        }).catch(function(err) {
-            that.log('tcc Failed:', err);
-            updating = false;
-            callback(err);
-        });
-    },
-
-    getState: function(callback) {
-        const latestData = this.device && this.device.latestData;
-        if (!latestData || !latestData.fanData) {
-            callback(null, false);
-            return;
-        }
-        const fanState = tcc.toHomeBridgeFanSystem(latestData.fanData.fanMode);
-        this.log('getState is', fanState, this.name);
-        callback(null, Boolean(fanState));
-    },
-
-    getServices: function() {
-        const that = this;
-        that.log('getServices', this.name);
-
-        const informationService = new Service.AccessoryInformation();
-        informationService
-            .setCharacteristic(Characteristic.Manufacturer, 'Honeywell')
-            .setCharacteristic(Characteristic.Model, this.model || 'TCC Thermostat')
-            .setCharacteristic(Characteristic.Name, this.name)
-            .setCharacteristic(Characteristic.SerialNumber, String(this.deviceID));
-
-        const returnServices = [informationService];
-
-        if (this.showFanControl) {
-            that.log('Creating fan service...');
-            this.fanService = new Service.Fan(this.name);
-            this.fanService
-                .getCharacteristic(Characteristic.Name)
-                .on('get', this.getName.bind(this));
-            that.log('Fan service created!');
-        }
-
-        const latestData = this.device && this.device.latestData;
-        if (latestData && latestData.hasFan && latestData.fanData && latestData.fanData.fanModeOnAllowed) {
-
-            if (this.showFanControl) {
-                this.fanService
-                    .getCharacteristic(Characteristic.On)
-                    .on('get', this.getState.bind(this))
-                    .on('set', this.setState.bind(this));
-                returnServices.push(this.fanService);
-            }
-
-            if (this.showAuto) {
-                that.log('Creating switch for \'Auto\'...');
-                this.myMomemtarySwitchAuto = new Service.Switch('Auto', 'mode-auto');
-                this.myMomemtarySwitchAuto
-                    .getCharacteristic(Characteristic.On)
-                    .on('get', callback => callback(null, false))
-                    .on('set', (s, callback) => {
-                        if (s === true) {
-                            this.setState(0, callback);
-                            setTimeout(() => {
-                                this.myMomemtarySwitchAuto.updateCharacteristic(Characteristic.On, false);
-                            }, 500);
-                        } else {
-                            callback(null);
-                        }
-                    });
-                returnServices.push(this.myMomemtarySwitchAuto);
-                that.log('\'Auto\' switch created!');
-            }
-
-            if (this.showOn) {
-                that.log('Creating switch for \'On\'...');
-                this.myMomemtarySwitchOn = new Service.Switch('On', 'mode-on');
-                this.myMomemtarySwitchOn
-                    .getCharacteristic(Characteristic.On)
-                    .on('get', callback => callback(null, false))
-                    .on('set', (s, callback) => {
-                        if (s === true) {
-                            this.setState(1, callback);
-                            setTimeout(() => {
-                                this.myMomemtarySwitchOn.updateCharacteristic(Characteristic.On, false);
-                            }, 500);
-                        } else {
-                            callback(null);
-                        }
-                    });
-                returnServices.push(this.myMomemtarySwitchOn);
-                that.log('\'On\' switch created!');
-            }
-
-            if (this.showCirculate) {
-                that.log('Creating switch for \'Circulate\'...');
-                this.myMomemtarySwitchCirculate = new Service.Switch('Circulate', 'mode-circulate');
-                this.myMomemtarySwitchCirculate
-                    .getCharacteristic(Characteristic.On)
-                    .on('get', callback => callback(null, false))
-                    .on('set', (s, callback) => {
-                        if (s === true) {
-                            this.setState(2, callback);
-                            setTimeout(() => {
-                                this.myMomemtarySwitchCirculate.updateCharacteristic(Characteristic.On, false);
-                            }, 500);
-                        } else {
-                            callback(null);
-                        }
-                    });
-                returnServices.push(this.myMomemtarySwitchCirculate);
-                that.log('\'Circulate\' switch created!');
-            }
-
-            if (this.showFollowSchedule) {
-                that.log('Creating switch for \'Follow Schedule\'...');
-                this.myMomemtarySwitchFollowSchedule = new Service.Switch('Follow Schedule', 'mode-follow-schedule');
-                this.myMomemtarySwitchFollowSchedule
-                    .getCharacteristic(Characteristic.On)
-                    .on('get', callback => callback(null, false))
-                    .on('set', (s, callback) => {
-                        if (s === true) {
-                            this.setState(3, callback);
-                            setTimeout(() => {
-                                this.myMomemtarySwitchFollowSchedule.updateCharacteristic(Characteristic.On, false);
-                            }, 500);
-                        } else {
-                            callback(null);
-                        }
-                    });
-                returnServices.push(this.myMomemtarySwitchFollowSchedule);
-                that.log('\'Follow Schedule\' switch created!');
-            }
-        } else if (this.showFanControl && this.fanService) {
-            // Fan service exists but device doesn't report fan capability yet
-            returnServices.push(this.fanService);
-        }
-
-        return returnServices;
+// Push the correct on/off state to every mode switch without triggering set handlers
+tccAccessory.prototype.updateAllSwitches = function(mode) {
+    for (const [modeKey, svc] of Object.entries(this.modeServices)) {
+        svc.getCharacteristic(Characteristic.On).updateValue(Number(modeKey) === mode);
     }
+};
+
+tccAccessory.prototype.setFanMode = function(mode, callback) {
+    const that = this;
+
+    if (updating) {
+        callback(null);
+        return;
+    }
+    updating = true;
+
+    that.log('Setting fan mode for', this.name, 'to', mode);
+
+    tcc.login(this.username, this.password).then(function(newSession) {
+        return newSession.setFanSwitch(that.deviceID, mode);
+    }).then(function(taskId) {
+        that.log('Fan mode set successfully', taskId);
+        updating = false;
+        updateValues(that);
+        callback(null);
+    }).catch(function(err) {
+        that.log('setFanMode failed:', err);
+        updating = false;
+        callback(err);
+    });
+};
+
+tccAccessory.prototype.getServices = function() {
+    const that = this;
+    that.log('getServices', this.name);
+
+    const informationService = new Service.AccessoryInformation();
+    informationService
+        .setCharacteristic(Characteristic.Manufacturer, 'Honeywell')
+        .setCharacteristic(Characteristic.Model, this.model || 'TCC Thermostat')
+        .setCharacteristic(Characteristic.Name, this.name)
+        .setCharacteristic(Characteristic.SerialNumber, String(this.deviceID));
+
+    const returnServices = [informationService];
+
+    const latestData = this.device && this.device.latestData;
+    const hasFan = latestData && latestData.hasFan && latestData.fanData && latestData.fanData.fanModeOnAllowed;
+
+    // Legacy on/off fan toggle
+    if (this.showFanControl) {
+        this.fanService = new Service.Fan(this.name);
+        this.fanService
+            .getCharacteristic(Characteristic.Name)
+            .on('get', cb => cb(null, this.name));
+
+        if (hasFan) {
+            this.fanService
+                .getCharacteristic(Characteristic.On)
+                .on('get', cb => cb(null, tcc.toHomeBridgeFanSystem(this.getCurrentMode())))
+                .on('set', (value, cb) => this.setFanMode(value ? MODE_ON : MODE_AUTO, cb));
+        }
+
+        returnServices.push(this.fanService);
+    }
+
+    if (!hasFan) return returnServices;
+
+    // Stateful, mutually exclusive mode switches
+    const modeDefs = [
+        { key: 'showAuto',           name: 'Auto',            mode: MODE_AUTO,            subtype: 'mode-auto' },
+        { key: 'showOn',             name: 'On',              mode: MODE_ON,              subtype: 'mode-on' },
+        { key: 'showCirculate',      name: 'Circulate',       mode: MODE_CIRCULATE,       subtype: 'mode-circulate' },
+        { key: 'showFollowSchedule', name: 'Follow Schedule', mode: MODE_FOLLOW_SCHEDULE, subtype: 'mode-follow-schedule' },
+    ];
+
+    const currentMode = this.getCurrentMode();
+
+    modeDefs.forEach(({ key, name, mode, subtype }) => {
+        if (!this[key]) return;
+
+        const svc = new Service.Switch(name, subtype);
+
+        svc.getCharacteristic(Characteristic.On)
+            .on('get', cb => cb(null, this.getCurrentMode() === mode))
+            .on('set', (value, cb) => {
+                if (value) {
+                    // User turned this mode on — activate it
+                    this.setFanMode(mode, cb);
+                } else {
+                    // User turned this mode off — fall back to Auto
+                    // (ignored if this switch IS Auto, since Auto turning off = Auto)
+                    this.setFanMode(mode === MODE_AUTO ? MODE_AUTO : MODE_AUTO, cb);
+                }
+            });
+
+        // Set initial state
+        svc.getCharacteristic(Characteristic.On).updateValue(currentMode === mode);
+
+        this.modeServices[mode] = svc;
+        returnServices.push(svc);
+        that.log(`'${name}' mode switch created`);
+    });
+
+    return returnServices;
 };

--- a/index.js
+++ b/index.js
@@ -205,18 +205,34 @@ tccAccessory.prototype.setFanMode = function(mode, callback) {
 
     that.log('Setting fan mode for', this.name, 'to', mode);
 
-    tcc.login(this.username, this.password).then(function(newSession) {
-        return newSession.setFanSwitch(that.deviceID, mode);
-    }).then(function(taskId) {
-        that.log('Fan mode set successfully', taskId);
-        updating = false;
-        updateValues(that);
-        callback(null);
-    }).catch(function(err) {
-        that.log('setFanMode failed:', err);
-        updating = false;
-        callback(err);
-    });
+    // Use the existing session — no need to re-login on every tap.
+    // Only re-login if the request fails (e.g. session expired).
+    session.setFanSwitch(that.deviceID, mode)
+        .then(function() {
+            that.log('Fan mode set to', mode);
+            updating = false;
+            updateValues(that);
+            callback(null);
+        })
+        .catch(function(err) {
+            that.log('setFanMode failed, attempting re-login:', err.message || err);
+            tcc.login(that.username, that.password)
+                .then(function(newSession) {
+                    session = newSession;
+                    return session.setFanSwitch(that.deviceID, mode);
+                })
+                .then(function() {
+                    that.log('Fan mode set to', mode, '(after re-login)');
+                    updating = false;
+                    updateValues(that);
+                    callback(null);
+                })
+                .catch(function(retryErr) {
+                    that.log('setFanMode failed after re-login:', retryErr.message || retryErr);
+                    updating = false;
+                    callback(retryErr);
+                });
+        });
 };
 
 tccAccessory.prototype.getServices = function() {

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -8,17 +8,26 @@ const { CookieJar } = require('tough-cookie');
 let Characteristic;
 let debug = false;
 
-// One shared cookie jar for the session
+// One shared cookie jar — persists session across all requests
 const jar = new CookieJar();
 const client = wrapper(axios.create({ jar }));
 
-const COMMON_HEADERS = {
-    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-    'Host': 'mytotalconnectcomfort.com',
-    'DNT': '1',
-    'Origin': 'https://mytotalconnectcomfort.com/portal',
-    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36'
+const PORTAL = 'https://mytotalconnectcomfort.com/portal/';
+
+// Current macOS Safari UA — less suspicious than Chrome 28 from 2013
+const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+    + 'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+
+const BROWSER_HEADERS = {
+    'User-Agent':                USER_AGENT,
+    'Accept':                    'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language':           'en-US,en;q=0.9',
+    'Accept-Encoding':           'gzip, deflate, br',
+    'Connection':                'keep-alive',
+    'Upgrade-Insecure-Requests': '1',
 };
+
+// ─── Session ────────────────────────────────────────────────────────────────
 
 function Session(username, password) {
     this.username = username;
@@ -26,137 +35,152 @@ function Session(username, password) {
 }
 
 Session.prototype.CheckDataSession = function(deviceID, cb) {
-    const utc_seconds = Date.now();
-    const url = `https://mytotalconnectcomfort.com/portal/Device/CheckDataSession/${deviceID}?_=${utc_seconds}`;
-
+    const url = `https://mytotalconnectcomfort.com/portal/Device/CheckDataSession/${deviceID}?_=${Date.now()}`;
     this._request(url)
         .then(json => cb(null, json))
         .catch(err => {
-            console.log('CDS Failed:', err);
+            console.log('CheckDataSession failed:', err.message || err);
             cb(err);
         });
 };
 
 Session.prototype.setFanSwitch = function(deviceId, fanSwitch) {
     const url = 'https://mytotalconnectcomfort.com/portal/Device/SubmitControlScreenChanges';
-
     const body = {
-        DeviceID: Number(deviceId),
-        SystemSwitch: null,
-        HeatSetpoint: null,
-        CoolSetpoint: null,
+        DeviceID:      Number(deviceId),
+        SystemSwitch:  null,
+        HeatSetpoint:  null,
+        CoolSetpoint:  null,
         HeatNextPeriod: null,
         CoolNextPeriod: null,
-        StatusHeat: null,
-        StatusCool: null,
-        FanMode: Number(fanSwitch)
+        StatusHeat:    null,
+        StatusCool:    null,
+        FanMode:       Number(fanSwitch)
     };
-
     if (debug) console.log('setFanSwitch', body);
 
     return client.post(url, body, {
+        timeout: 30000,
         headers: {
-            'Accept': 'application/json, text/javascript, */*; q=0.01',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'Content-Type': 'application/json; charset=UTF-8',
-            'Host': 'mytotalconnectcomfort.com',
-            'Origin': 'https://mytotalconnectcomfort.com',
-            'Referer': `https://mytotalconnectcomfort.com/portal/Device/Control/${deviceId}`,
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36',
-            'X-Requested-With': 'XMLHttpRequest'
+            'User-Agent':      USER_AGENT,
+            'Accept':          'application/json, text/javascript, */*; q=0.01',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Content-Type':    'application/json; charset=UTF-8',
+            'Referer':         `https://mytotalconnectcomfort.com/portal/Device/Control/${deviceId}`,
+            'Origin':          'https://mytotalconnectcomfort.com',
+            'X-Requested-With': 'XMLHttpRequest',
         }
-    }).then(response => response.data);
+    }).then(r => r.data);
 };
 
 Session.prototype._request = function(url) {
     return client.get(url, {
-        timeout: 15000,
+        timeout: 30000,
         headers: {
-            'Accept': '*/*',
-            'DNT': '1',
-            'Cache-Control': 'max-age=0',
-            'Accept-Language': 'en-US,en;q=0.8',
-            'Connection': 'keep-alive',
-            'Host': 'mytotalconnectcomfort.com',
-            'Referer': 'https://mytotalconnectcomfort.com/portal/',
+            'User-Agent':      USER_AGENT,
+            'Accept':          'application/json, text/javascript, */*; q=0.01',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Referer':         PORTAL,
             'X-Requested-With': 'XMLHttpRequest',
-            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36'
         }
-    }).then(response => response.data);
+    }).then(r => r.data);
 };
 
-function login(username, password) {
-    // Step 1: GET to obtain initial session cookies
-    return client.get('https://mytotalconnectcomfort.com/portal/', {
-        timeout: 30000,
-        headers: COMMON_HEADERS
-    }).then(() => {
-        // Step 2 & 3: POST credentials; axios auto-follows the 302 redirect.
-        // Timeout is generous — the POST returns a 302 and axios follows it,
-        // so we're covering two round-trips in one call.
-        const params = new URLSearchParams({
-            UserName: username,
-            Password: password,
-            RememberMe: 'false'
-        });
+// ─── Login ──────────────────────────────────────────────────────────────────
 
-        return client.post('https://mytotalconnectcomfort.com/portal/', params.toString(), {
+function extractCsrfToken(html) {
+    // ASP.NET MVC anti-forgery token hidden field
+    const patterns = [
+        /name="__RequestVerificationToken"[^>]*value="([^"]+)"/,
+        /value="([^"]+)"[^>]*name="__RequestVerificationToken"/,
+    ];
+    for (const re of patterns) {
+        const m = html.match(re);
+        if (m) return m[1];
+    }
+    return null;
+}
+
+function login(username, password) {
+    if (debug) console.log('TCC login: fetching login page...');
+
+    // Step 1 — GET the login page to collect session cookies + CSRF token
+    return client.get(PORTAL, {
+        timeout: 30000,
+        headers: BROWSER_HEADERS,
+    }).then(response => {
+        const html = typeof response.data === 'string' ? response.data : '';
+        const csrfToken = extractCsrfToken(html);
+
+        if (debug) console.log('TCC login: CSRF token', csrfToken ? 'found' : 'NOT FOUND');
+
+        const params = new URLSearchParams();
+        params.append('UserName', username);
+        params.append('Password', password);
+        params.append('RememberMe', 'false');
+        if (csrfToken) params.append('__RequestVerificationToken', csrfToken);
+
+        // Step 2 — POST credentials; axios auto-follows the 302 → authenticated page
+        return client.post(PORTAL, params.toString(), {
             timeout: 30000,
             headers: {
-                ...COMMON_HEADERS,
-                'Content-Type': 'application/x-www-form-urlencoded'
+                ...BROWSER_HEADERS,
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Referer':      PORTAL,
+                'Origin':       'https://mytotalconnectcomfort.com',
             }
         });
     }).then(response => {
-        if (response.status !== 200) {
-            throw new Error(`TCC Login failed, please check your credentials (status ${response.status})`);
+        // If we ended up back at the login page, credentials were rejected
+        const html = typeof response.data === 'string' ? response.data : '';
+        const landedOnLogin = html.includes('id="loginForm"')
+            || html.includes('name="UserName"')
+            || html.includes('name="Password"');
+
+        if (landedOnLogin) {
+            throw new Error('TCC Login failed — credentials rejected (landed back on login page)');
         }
+
+        if (debug) console.log('TCC login: success');
     });
 }
 
+// ─── Exports ─────────────────────────────────────────────────────────────────
+
 module.exports = {
     login: function(username, password) {
-        return login(username, password).then(() => {
-            return new Session(username, password);
-        }).catch(err => {
-            console.log('TCC Login Failed:', err.message || err);
-            throw err;
-        });
+        return login(username, password)
+            .then(() => new Session(username, password))
+            .catch(err => {
+                console.log('TCC Login Failed:', err.message || err);
+                throw err;
+            });
     }
 };
 
-// Maps TCC fan mode (0-3) to HomeKit boolean (on/off).
-// Modes where the fan is actively doing something (On, Circulate) → true
-// Modes where the fan is passive/automated (Auto, Follow Schedule) → false
+// Maps TCC fan mode (0-3) to HomeKit boolean.
+// Modes where the fan is actively doing something → true
+// Modes where the fan is passive/automated → false
 module.exports.toHomeBridgeFanSystem = function(fanMode) {
     switch (fanMode) {
-        case 0: return false;  // Auto — passive
-        case 1: return true;   // On — actively forced on
-        case 2: return true;   // Circulate — actively running periodically
-        case 3: return false;  // Follow Schedule — automated, like Auto
+        case 0: return false;  // Auto
+        case 1: return true;   // On
+        case 2: return true;   // Circulate
+        case 3: return false;  // Follow Schedule
         default:
             console.log('Unexpected fanMode value [%s]', fanMode);
             return false;
     }
 };
 
-// Maps HomeKit boolean to TCC fan mode.
-// Toggling on/off always goes to On (1) or Auto (0).
-// Use the momentary switches to set Circulate (2) or Follow Schedule (3).
+// Toggling on/off always uses On(1) / Auto(0).
+// Use mode switches for Circulate(2) or Follow Schedule(3).
 module.exports.toTCCFanSystem = function(fanSystem) {
-    switch (fanSystem) {
-        case true:  return 1;  // On
-        case false: return 0;  // Auto
-        default:
-            console.log('Unexpected fanSystem value [%s]', fanSystem);
-            return 0;
-    }
+    return fanSystem ? 1 : 0;
 };
 
 module.exports.isEmptyObject = function(obj) {
-    for (const name in obj) {
-        return false;
-    }
+    for (const name in obj) return false;
     return true;
 };
 
@@ -165,9 +189,7 @@ module.exports.diff = function(obj1, obj2) {
     for (const key in obj1) {
         if (typeof obj2[key] === 'object' && typeof obj1[key] === 'object') {
             const change = module.exports.diff(obj1[key], obj2[key]);
-            if (!module.exports.isEmptyObject(change)) {
-                result[key] = change;
-            }
+            if (!module.exports.isEmptyObject(change)) result[key] = change;
         } else if (obj2[key] !== obj1[key]) {
             result[key] = obj2[key];
         }
@@ -179,10 +201,5 @@ module.exports.deepEquals = function(o1, o2) {
     return JSON.stringify(o1) === JSON.stringify(o2);
 };
 
-module.exports.setCharacteristic = function(data) {
-    Characteristic = data;
-};
-
-module.exports.setDebug = function(data) {
-    debug = data;
-};
+module.exports.setCharacteristic = function(data) { Characteristic = data; };
+module.exports.setDebug         = function(data) { debug = data; };

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -61,6 +61,10 @@ Session.prototype.setFanSwitch = function(deviceId, fanSwitch) {
 
     return client.post(url, body, {
         timeout: 30000,
+        // The server redirects to /portal/Device/Control/{id} after the POST.
+        // We don't need to follow it — the POST itself is what sets the fan mode.
+        maxRedirects: 0,
+        validateStatus: status => status >= 200 && status < 400,
         headers: {
             'User-Agent':      USER_AGENT,
             'Accept':          'application/json, text/javascript, */*; q=0.01',

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -1,341 +1,164 @@
 /*jslint node: true */
 'use strict';
 
-var Q = require('q');
-var request = require('request');
-var jar = request.jar();
-var _ = require('lodash');
-var Characteristic;
-var debug = false;
-var ldebug = false;   // debugging of login errors - too verbose
+const axios = require('axios');
+const { wrapper } = require('axios-cookiejar-support');
+const { CookieJar } = require('tough-cookie');
 
-var sessionCredentials = {};
+let Characteristic;
+let debug = false;
 
-function Session(username, password, appId) {
-    //  console.log(username, password, appId, json);
-    //  this.sessionId = json.sessionId;
-    //  this.userInfo = new UserInfo(json.userInfo);
-    //  this.latestEulaAccepted = json.latestEulaAccepted;
+// One shared cookie jar for the session
+const jar = new CookieJar();
+const client = wrapper(axios.create({ jar }));
 
-    sessionCredentials[this.sessionId] = {
-        username: username,
-        password: password,
-        appId: appId
-    };
+const COMMON_HEADERS = {
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Host': 'mytotalconnectcomfort.com',
+    'DNT': '1',
+    'Origin': 'https://mytotalconnectcomfort.com/portal',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36'
+};
+
+function Session(username, password) {
+    this.username = username;
+    this.password = password;
 }
 
 Session.prototype.CheckDataSession = function(deviceID, cb) {
-    var utc_seconds = Date.now();
+    const utc_seconds = Date.now();
+    const url = `https://mytotalconnectcomfort.com/portal/Device/CheckDataSession/${deviceID}?_=${utc_seconds}`;
 
-    var url = "https://mytotalconnectcomfort.com/portal/Device/CheckDataSession/" + deviceID + "?_=" + utc_seconds;
-
-    this._request(url).then(function(json) {
-        cb(null, json);
-    }.bind(this)).fail(function(err) {
-        console.log('CDS Failed:', err);
-        cb(err);
-    });
-
-}
-
-// {"DeviceID":1234567,"SystemSwitch":null,"HeatSetpoint":14,"CoolSetpoint":null,"HeatNextPeriod":null,"CoolNextPeriod"
-// :null,"StatusHeat":1,"StatusCool":1,"FanMode":null}
-// {"DeviceID":1234567,"SystemSwitch":null,"HeatSetpoint":20,"CoolSetpoint":null,"HeatNextPeriod":null,"CoolNextPeriod"
-// :null,"StatusHeat":null,"StatusCool":null,"FanMode":null}
+    this._request(url)
+        .then(json => cb(null, json))
+        .catch(err => {
+            console.log('CDS Failed:', err);
+            cb(err);
+        });
+};
 
 Session.prototype.setFanSwitch = function(deviceId, fanSwitch) {
-    var deferred = Q.defer();
-    var url = "https://mytotalconnectcomfort.com/portal/Device/SubmitControlScreenChanges";
+    const url = 'https://mytotalconnectcomfort.com/portal/Device/SubmitControlScreenChanges';
 
-    var body = JSON.stringify({
-        "DeviceID": Number(deviceId),
-        "SystemSwitch": null,
-        "HeatSetpoint": null,
-        "CoolSetpoint": null,
-        "HeatNextPeriod": null,
-        "CoolNextPeriod": null,
-        "StatusHeat": null,
-        "StatusCool": null,
-        "FanMode": Number(fanSwitch)
-    });
+    const body = {
+        DeviceID: Number(deviceId),
+        SystemSwitch: null,
+        HeatSetpoint: null,
+        CoolSetpoint: null,
+        HeatNextPeriod: null,
+        CoolNextPeriod: null,
+        StatusHeat: null,
+        StatusCool: null,
+        FanMode: Number(fanSwitch)
+    };
 
-    if (debug)
-        console.log("setFanSwitch", body);
+    if (debug) console.log('setFanSwitch', body);
 
-    request({
-        method: 'POST',
-        url: url,
-        jar: jar,
+    return client.post(url, body, {
         headers: {
             'Accept': 'application/json, text/javascript, */*; q=0.01',
-            'Accept-Encoding': 'gzip, deflate',
             'Accept-Language': 'en-US,en;q=0.5',
-            'Connection': 'Keep-Alive',
-            'Cache-Control': 'no-cache',
             'Content-Type': 'application/json; charset=UTF-8',
-            'DNT': 1,
             'Host': 'mytotalconnectcomfort.com',
             'Origin': 'https://mytotalconnectcomfort.com',
-            'Referer': 'https://mytotalconnectcomfort.com/portal/Device/Control/' + deviceId,
+            'Referer': `https://mytotalconnectcomfort.com/portal/Device/Control/${deviceId}`,
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36',
             'X-Requested-With': 'XMLHttpRequest'
-        },
-        body: body
-    }, function(err, response) {
-        if (err || response.statusCode != 200 || response.statusMessage != "OK") {
-            if (err) {
-                console.error(err);
-            } else {
-                console.log("Error ", response.statusCode);
-                deferred.reject("HTTP Error ", response.statusCode);
-            }
-            return err;
-
-        } else {
-            var json;
-            //    console.log(response.body);
-            try {
-                json = JSON.parse(response.body);
-            } catch (ex) {
-                //                console.error(ex);
-                console.error(response.statusCode, response.statusMessage);
-                console.error(response.body);
-                //                console.error(response);
-                deferred.reject(ex);
-            }
-            if (json) {
-                deferred.resolve(json);
-            }
         }
-    });
-
-    return deferred.promise;
-}
+    }).then(response => response.data);
+};
 
 Session.prototype._request = function(url) {
-    var deferred = Q.defer();
-    request({
-        method: 'GET',
-        url: url,
-        jar: jar,
+    return client.get(url, {
         timeout: 15000,
         headers: {
-            "Accept": "*/*",
-            "DNT": "1",
-            "Accept-Encoding": "plain",
-            "Cache-Control": "max-age=0",
-            "Accept-Language": "en-US,en,q=0.8",
-            "Connection": "keep-alive",
-            "Host": "mytotalconnectcomfort.com",
-            "Referer": "https://mytotalconnectcomfort.com/portal/",
-            "X-Requested-With": "XMLHttpRequest",
-            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36"
+            'Accept': '*/*',
+            'DNT': '1',
+            'Cache-Control': 'max-age=0',
+            'Accept-Language': 'en-US,en;q=0.8',
+            'Connection': 'keep-alive',
+            'Host': 'mytotalconnectcomfort.com',
+            'Referer': 'https://mytotalconnectcomfort.com/portal/',
+            'X-Requested-With': 'XMLHttpRequest',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36'
         }
-    }, function(err, response) {
-        if (err || response.statusCode != 200 || response.statusMessage != "OK") {
-            if (err) {
-                console.log("Error _request", url, err);
-                deferred.reject(err);
-            } else {
-                console.log("Error _request", url, response.statusCode);
-                deferred.reject("HTTP Error " + response.statusCode);
-            }
-            return err;
-
-        } else {
-            var json;
-            //console.log("_request", url, response.body);
-            try {
-                json = JSON.parse(response.body);
-            } catch (ex) {
-                //                console.error(ex);
-                console.error(response.statusCode, response.statusMessage);
-                console.error(response.body);
-                //                console.error(response);
-                deferred.reject(ex);
-            }
-            if (json) {
-                deferred.resolve(json);
-            }
-        }
-    });
-
-    return deferred.promise;
-}
+    }).then(response => response.data);
+};
 
 function login(username, password) {
-    var deferred = Q.defer();
-    request({
-        jar: jar,
-        method: 'GET',
-        url: 'https://mytotalconnectcomfort.com/portal/',
+    // Step 1: GET to obtain initial session cookies
+    return client.get('https://mytotalconnectcomfort.com/portal/', {
         timeout: 10000,
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Encoding": "sdch",
-            "Host": "mytotalconnectcomfort.com",
-            "DNT": "1",
-            "Origin": "https://mytotalconnectcomfort.com/portal",
-            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36"
-        },
+        headers: COMMON_HEADERS
+    }).then(() => {
+        // Step 2 & 3: POST credentials; axios auto-follows the 302 redirect
+        const params = new URLSearchParams({
+            UserName: username,
+            Password: password,
+            RememberMe: 'false'
+        });
 
-    }, function(err, response) {
-        // Response s/b 200 OK
-        if (err || response.statusCode != 200) {
-            console.log("TCC Login Failed, can't connect to TCC Web Site", err);
-            deferred.reject("TCC Login failed, can't connect to TCC Web Site");
-            return err;
-        } else {
-            if (ldebug) {
-                console.log(response.statusCode);
-                console.log(response.statusMessage);
-                console.log("-------------------------------------------");
-                console.log(response.headers);
-                console.log("-------------------------------------------");
-                console.log(response.body);
-                console.log("-------------------------------------------");
+        return client.post('https://mytotalconnectcomfort.com/portal/', params.toString(), {
+            timeout: 10000,
+            headers: {
+                ...COMMON_HEADERS,
+                'Content-Type': 'application/x-www-form-urlencoded'
             }
-            request({
-                jar: jar,
-                method: 'POST',
-                url: 'https://mytotalconnectcomfort.com/portal/',
-                timeout: 10000,
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                    "Accept-Encoding": "sdch",
-                    "Host": "mytotalconnectcomfort.com",
-                    "DNT": "1",
-                    "Origin": "https://mytotalconnectcomfort.com/portal",
-                    "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36"
-                },
-                form: {
-                    UserName: username,
-                    Password: password,
-                    RememberMe: "false"
-                        //		ApplicationId: appId
-                }
-            }, function(err, response) {
-                // response s/b 302
-                if (err || response.statusCode != 302) {
-                    console.log("TCC Login Failed - POST", err);
-                    if (response) console.log(response.statusCode);
-                    deferred.reject("TCC Login failed, please check your credentials");
-                    return err;
-
-                } else {
-                    if (ldebug) {
-                        console.log(response.statusCode);
-                        console.log(response.statusMessage);
-                        console.log("-------------------------------------------");
-                        console.log(response.headers);
-                        console.log("-------------------------------------------");
-                        console.log(response.body);
-                        console.log("-------------------------------------------");
-                    }
-                    request({
-                        jar: jar,
-                        method: 'GET',
-                        url: 'https://mytotalconnectcomfort.com/portal/',
-                        timeout: 10000,
-                        headers: {
-                            "Content-Type": "application/x-www-form-urlencoded",
-                            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                            "Accept-Encoding": "sdch",
-                            "Host": "mytotalconnectcomfort.com",
-                            "DNT": "1",
-                            "Origin": "https://mytotalconnectcomfort.com/portal",
-                            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36"
-                        },
-
-                    }, function(err, response) {
-                        if (err || response.statusCode != 200) {
-                            console.log("TCC Login failed - GET", err);
-                            if (response) console.log(response.statusCode);
-                            deferred.reject("TCC Login failed - GET");
-
-                            return err;
-                        } else {
-                            if (ldebug) {
-                                console.log(response.statusCode);
-                                console.log(response.statusMessage);
-                                console.log("-------------------------------------------");
-                                console.log(response.headers);
-                                console.log("-------------------------------------------");
-                                console.log(response.body);
-                                console.log("-------------------------------------------");
-                            }
-                            deferred.resolve(response.statusCode);
-                        }
-                    });
-
-                }
-            });
+        });
+    }).then(response => {
+        if (response.status !== 200) {
+            throw new Error(`TCC Login failed, please check your credentials (status ${response.status})`);
         }
     });
-
-    return deferred.promise;
 }
 
 module.exports = {
-    login: function(username, password, appId) {
-        return login(username, password, appId).then(function(json) {
-            return new Session(username, password, appId, json);
+    login: function(username, password) {
+        return login(username, password).then(() => {
+            return new Session(username, password);
+        }).catch(err => {
+            console.log('TCC Login Failed:', err.message || err);
+            throw err;
         });
     }
 };
 
-// Utility Functions
-
-
 module.exports.toHomeBridgeFanSystem = function(fanSystem) {
     switch (fanSystem) {
-        case 1:
-            // ON
-            return true;
-        case 0:
-            // auto
-            return false;
+        case 1: return true;   // On
+        case 0: return false;  // Auto
         default:
-            // auto is only one that should show as off
-            console.log("Unexpected fanSystem value [%s]", fanSystem)
+            console.log('Unexpected fanSystem value [%s]', fanSystem);
             return true;
     }
-}
+};
 
 module.exports.toTCCFanSystem = function(fanSystem) {
     switch (fanSystem) {
-        case true:
-            // ON
-            return 1;
-        case false:
-            // auto
-            return 0;
+        case true: return 1;   // On
+        case false: return 0;  // Auto
         default:
-            console.log("Unexpected fanSystem value [%s]", fanSystem)
+            console.log('Unexpected fanSystem value [%s]', fanSystem);
             return 0;
     }
-}
+};
 
 module.exports.isEmptyObject = function(obj) {
-    var name;
-    for (name in obj) {
+    for (const name in obj) {
         return false;
     }
     return true;
 };
 
 module.exports.diff = function(obj1, obj2) {
-    var result = {};
-    var change;
-    for (var key in obj1) {
-        if (typeof obj2[key] == 'object' && typeof obj1[key] == 'object') {
-            change = module.exports.diff(obj1[key], obj2[key]);
-            if (module.exports.isEmptyObject(change) === false) {
+    const result = {};
+    for (const key in obj1) {
+        if (typeof obj2[key] === 'object' && typeof obj1[key] === 'object') {
+            const change = module.exports.diff(obj1[key], obj2[key]);
+            if (!module.exports.isEmptyObject(change)) {
                 result[key] = change;
             }
-        } else if (obj2[key] != obj1[key]) {
+        } else if (obj2[key] !== obj1[key]) {
             result[key] = obj2[key];
         }
     }
@@ -344,12 +167,12 @@ module.exports.diff = function(obj1, obj2) {
 
 module.exports.deepEquals = function(o1, o2) {
     return JSON.stringify(o1) === JSON.stringify(o2);
-}
+};
 
 module.exports.setCharacteristic = function(data) {
     Characteristic = data;
-}
+};
 
 module.exports.setDebug = function(data) {
     debug = data;
-}
+};

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -12,6 +12,20 @@ let debug = false;
 const jar = new CookieJar();
 const client = wrapper(axios.create({ jar }));
 
+// Pre-seed cookies that are normally set by JavaScript on the TCC site.
+// Without these the server may redirect to a consent wall or bot check.
+(function seedCookies() {
+    const domain = 'https://mytotalconnectcomfort.com';
+    const base   = 'Domain=mytotalconnectcomfort.com; Path=/; Secure';
+    [
+        `checkCookie=checkValue; ${base}`,
+        `cmapi_cookie_privacy=permit_1|2|3; ${base}`,
+        `notice_gdpr_prefs=0|1|2:; ${base}`,
+        `notice_preferences=2:; ${base}`,
+        `notice_behavior=implied|us; ${base}`,
+    ].forEach(c => jar.setCookieSync(c, domain));
+}());
+
 const PORTAL = 'https://mytotalconnectcomfort.com/portal/';
 
 // Current macOS Safari UA — less suspicious than Chrome 28 from 2013
@@ -61,18 +75,22 @@ Session.prototype.setFanSwitch = function(deviceId, fanSwitch) {
 
     return client.post(url, body, {
         timeout: 30000,
-        // The server redirects to /portal/Device/Control/{id} after the POST.
-        // We don't need to follow it — the POST itself is what sets the fan mode.
+        // Server redirects to /portal/Device/Control/{id} after accepting the POST.
+        // We don't need to follow it — stop here and treat 2xx/3xx as success.
         maxRedirects: 0,
         validateStatus: status => status >= 200 && status < 400,
         headers: {
-            'User-Agent':      USER_AGENT,
-            'Accept':          'application/json, text/javascript, */*; q=0.01',
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Content-Type':    'application/json; charset=UTF-8',
-            'Referer':         `https://mytotalconnectcomfort.com/portal/Device/Control/${deviceId}`,
-            'Origin':          'https://mytotalconnectcomfort.com',
+            'User-Agent':       USER_AGENT,
+            'Accept':           'application/json, text/javascript, */*; q=0.01',
+            'Accept-Language':  'en-US,en;q=0.9',
+            'Accept-Encoding':  'gzip, deflate, br, zstd',
+            'Content-Type':     'application/json; charset=utf-8',
+            'Origin':           'https://mytotalconnectcomfort.com',
+            'Referer':          `https://mytotalconnectcomfort.com/portal/Device/Control/${deviceId}`,
             'X-Requested-With': 'XMLHttpRequest',
+            'Sec-Fetch-Site':   'same-origin',
+            'Sec-Fetch-Mode':   'cors',
+            'Sec-Fetch-Dest':   'empty',
         }
     }).then(r => r.data);
 };

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -123,19 +123,27 @@ module.exports = {
     }
 };
 
-module.exports.toHomeBridgeFanSystem = function(fanSystem) {
-    switch (fanSystem) {
-        case 1: return true;   // On
-        case 0: return false;  // Auto
+// Maps TCC fan mode (0-3) to HomeKit boolean (on/off).
+// Modes where the fan is actively doing something (On, Circulate) → true
+// Modes where the fan is passive/automated (Auto, Follow Schedule) → false
+module.exports.toHomeBridgeFanSystem = function(fanMode) {
+    switch (fanMode) {
+        case 0: return false;  // Auto — passive
+        case 1: return true;   // On — actively forced on
+        case 2: return true;   // Circulate — actively running periodically
+        case 3: return false;  // Follow Schedule — automated, like Auto
         default:
-            console.log('Unexpected fanSystem value [%s]', fanSystem);
-            return true;
+            console.log('Unexpected fanMode value [%s]', fanMode);
+            return false;
     }
 };
 
+// Maps HomeKit boolean to TCC fan mode.
+// Toggling on/off always goes to On (1) or Auto (0).
+// Use the momentary switches to set Circulate (2) or Follow Schedule (3).
 module.exports.toTCCFanSystem = function(fanSystem) {
     switch (fanSystem) {
-        case true: return 1;   // On
+        case true:  return 1;  // On
         case false: return 0;  // Auto
         default:
             console.log('Unexpected fanSystem value [%s]', fanSystem);

--- a/lib/tcc.js
+++ b/lib/tcc.js
@@ -88,10 +88,12 @@ Session.prototype._request = function(url) {
 function login(username, password) {
     // Step 1: GET to obtain initial session cookies
     return client.get('https://mytotalconnectcomfort.com/portal/', {
-        timeout: 10000,
+        timeout: 30000,
         headers: COMMON_HEADERS
     }).then(() => {
-        // Step 2 & 3: POST credentials; axios auto-follows the 302 redirect
+        // Step 2 & 3: POST credentials; axios auto-follows the 302 redirect.
+        // Timeout is generous — the POST returns a 302 and axios follows it,
+        // so we're covering two round-trips in one call.
         const params = new URLSearchParams({
             UserName: username,
             Password: password,
@@ -99,7 +101,7 @@ function login(username, password) {
         });
 
         return client.post('https://mytotalconnectcomfort.com/portal/', params.toString(), {
-            timeout: 10000,
+            timeout: 30000,
             headers: {
                 ...COMMON_HEADERS,
                 'Content-Type': 'application/x-www-form-urlencoded'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,215 +1,1051 @@
 {
   "name": "homebridge-tcc-fan-plus",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "2.0.0",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "optional": true
-    },
-    "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "optional": true
-    },
-    "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "optional": true
-    },
-    "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-      "optional": true
-    },
-    "boom": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
+  "packages": {
+    "": {
+      "name": "homebridge-tcc-fan-plus",
+      "version": "2.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.7.0",
+        "axios-cookiejar-support": "^2.0.0",
+        "tough-cookie": "^4.1.0"
+      },
+      "devDependencies": {
+        "homebridge": "^2.0.0-beta.0"
+      },
+      "engines": {
+        "homebridge": "^1.8.0 || ^2.0.0-beta.0",
+        "node": ">=18.15.0"
       }
     },
-    "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "optional": true,
-      "requires": {
-        "delayed-stream": "0.0.5"
+    "node_modules/@homebridge/ciao": {
+      "version": "1.3.7-beta.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7-beta.0.tgz",
+      "integrity": "sha512-5weIVai/zPePxedfTCuXGcx+hdItlTzow7mK7Q2xmT/7dQ4WX+HoCuMIXQSR1oFs1fNc4v/9yAqZmuWcC+4cMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
       }
     },
-    "cryptiles": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x"
+    "node_modules/@homebridge/dbus-native": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.4.tgz",
+      "integrity": "sha512-DtX16c/NNT/NJBFgy8qu74z/SZuAaS0GJahKIrS9ZZOYUHDtZYr1B4ZdjQlr+1NT7ZcCk6e84O4lAieiJq0Hsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-stream": "^4.0.1",
+        "hexy": "^0.4.0",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
+        "safe-buffer": "^5.1.2",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus2js": "bin/dbus2js.js"
       }
     },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "optional": true
-    },
-    "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "optional": true
-    },
-    "forever-agent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
-    },
-    "form-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-      "optional": true,
-      "requires": {
-        "async": "~0.9.0",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.11"
+    "node_modules/@homebridge/hap-nodejs": {
+      "version": "2.1.3-beta.1",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.3-beta.1.tgz",
+      "integrity": "sha512-1PLNe8E4u0L5NMvVIxutS1ujZKVPYAvTjEZ/Vc23khI2p6UO07RkkWU36tADNYevjX5n+d18nPOXg5Y2s8FdsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/ciao": "^1.3.7-beta.0",
+        "@homebridge/dbus-native": "^0.7.4",
+        "bonjour-hap": "^3.10.1",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "node-persist": "^0.0.12",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": "^22 || ^24"
       }
     },
-    "hawk": {
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@matter/general": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-Uc/S8pqZs7KABiRHZLa//sPH8mSOBA2+sPTGce7sezbU/CIWmGzu42g4xBEUzedIERU33iWcDgNlYw+fiKFjPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.2.0"
+      }
+    },
+    "node_modules/@matter/main": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-x6d5HsyB77dq811ZaYXcDvkRjkKJ7oS1XbPggDHLi6rwlD0pOicIgH+9UNGGrZTPj/9sLg5cVn9NbDe+/HTumw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/model": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/node": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/protocol": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/types": "0.17.0-alpha.0-20260417-8f958ba0d"
+      },
+      "optionalDependencies": {
+        "@matter/nodejs": "0.17.0-alpha.0-20260417-8f958ba0d"
+      }
+    },
+    "node_modules/@matter/model": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-uMZYbpRTAwQTbt7jBnq0jZoQ12QD5dn+XL4u4VL5tgFdEAsIXny2iKH21N0oL7TdzHn2EYk8s7S6japB4gmXhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d"
+      }
+    },
+    "node_modules/@matter/node": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-wx4N3pHzoWkF9ajwkG7ITsK4FolVcLyiQvmZkVuahtAGRUm7+RAFCBc0zFZ91fVcARYiOBDvKeNWuhQOn8+0nw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/model": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/protocol": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/types": "0.17.0-alpha.0-20260417-8f958ba0d"
+      }
+    },
+    "node_modules/@matter/nodejs": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-TI63eYUpke1xQOh+DHiNi1kXLySBEJUb/cKOS+RDoq88STSOin2OhXd4w/TrFFnpWw5VrZ4oCYEWmCT+GbDRGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/node": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/protocol": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/types": "0.17.0-alpha.0-20260417-8f958ba0d"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+      }
+    },
+    "node_modules/@matter/protocol": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-Y16QeByXyfooAZ3jMwdkOSYyuNbLMa8EpQvo4Yvd4EQydhFMonioXaEpxRGuvQuQzyHDYhkgQ5gQKxXlJSDURg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/model": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/types": "0.17.0-alpha.0-20260417-8f958ba0d"
+      }
+    },
+    "node_modules/@matter/types": {
+      "version": "0.17.0-alpha.0-20260417-8f958ba0d",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260417-8f958ba0d.tgz",
+      "integrity": "sha512-Caam+T6SOqFuyRMRZCheo/GK0MDO9dgN4itiaGyJmoW9IRm544NnCwAFhwSRKBKmF48XsfEWnadGBCvDoTbxzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "@matter/model": "0.17.0-alpha.0-20260417-8f958ba0d"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.5.tgz",
+      "integrity": "sha512-y5S8feB6SbITWEiisCqFzQWaob+M34vVz8sP5KmQTDovM7HJ8xG9KQIETh0bFRyXUfDzWR5aPzfgkTND0wuYvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+      },
+      "peerDependencies": {
+        "axios": ">=0.20.0",
+        "tough-cookie": ">=4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/axios/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-      "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.9.x",
-        "sntp": "0.2.x"
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
-    "hoek": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
-    },
-    "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "optional": true,
-      "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "^0.1.5",
-        "ctype": "0.5.3"
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    "node_modules/bonjour-hap": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.1.tgz",
+      "integrity": "sha512-StmRRG5LzJirg/1olvm2cWPJ/HeqrxyRa4cl2L6al0JoWJsH000uBM67R0RfBM3QAjcJrVjpMT3wDyg/v09osQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5",
+        "multicast-dns-service-types": "^1.1.0"
+      }
     },
-    "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
-    "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
-    "oauth-sign": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-      "optional": true
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
-    "psl": {
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-srp-hap": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
+      "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/futoin-hkdf": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
+      "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexy": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/homebridge": {
+      "version": "2.0.0-beta.99",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.99.tgz",
+      "integrity": "sha512-wBRHxFRmIiCEtCycWjZjMc5lmXShOPfOdgnow5+R0SxosPxGbeNuOqFJTOuDCcHZr7plwsYxmfeVL3bRU93Sqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/hap-nodejs": "2.1.3-beta.1",
+        "@matter/main": "0.17.0-alpha.0-20260417-8f958ba0d",
+        "chalk": "5.6.2",
+        "commander": "14.0.3",
+        "fs-extra": "11.3.4",
+        "qrcode-terminal": "0.12.0",
+        "semver": "7.7.4",
+        "source-map-support": "0.5.21"
+      },
+      "bin": {
+        "homebridge": "bin/homebridge.js"
+      },
+      "engines": {
+        "node": "^22 || ^24"
+      }
+    },
+    "node_modules/http-cookie-agent": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.6.tgz",
+      "integrity": "sha512-Ei0BDjMfy6MSXATmCZ5nWr935NLYl6eD/BTxVGOIrKAlg4xDtMdk+8a+caq6Qwa4FACn+vACj89pFKlXmHOnkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-persist": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+      "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "optional": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "optional": true
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "q": {
+    "node_modules/q": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
-      "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
-    },
-    "qs": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
-    },
-    "request": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
-      "integrity": "sha1-tdi5UmrdSi1GKfTUFxJFc5lkRa4=",
-      "requires": {
-        "aws-sign2": "~0.5.0",
-        "forever-agent": "~0.5.0",
-        "form-data": "~0.1.0",
-        "hawk": "~1.0.0",
-        "http-signature": "~0.10.0",
-        "json-stringify-safe": "~5.0.0",
-        "mime": "~1.2.9",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~0.6.0",
-        "tough-cookie": ">=0.12.0",
-        "tunnel-agent": "~0.3.0"
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "sntp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
-    "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "optional": true,
-      "requires": {
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "tunnel-agent": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
-      "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
-      "optional": true
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "optional": true
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Honeywell Total Connect Comfort Fan support for Homebridge - Alfred's fork with other fan mode switches.",
   "license": "ISC",
   "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
   "keywords": [
     "homebridge-plugin",
     "tcc",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "homebridge-tcc-fan-plus",
-  "version": "1.0.1",
+  "displayName": "TCC Fan Plus",
+  "version": "2.0.0",
   "description": "Honeywell Total Connect Comfort Fan support for Homebridge - Alfred's fork with other fan mode switches.",
   "license": "ISC",
+  "main": "index.js",
   "keywords": [
     "homebridge-plugin",
     "tcc",
@@ -16,12 +18,15 @@
     "url": "https://github.com/Freddicus/homebridge-tcc-fan/issues"
   },
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.4.16"
+    "node": ">=18.15.0",
+    "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
-    "q": "~1.0.1",
-    "request": "~2.34.0"
+    "axios": "^1.7.0",
+    "axios-cookiejar-support": "^2.0.0",
+    "tough-cookie": "^4.1.0"
+  },
+  "devDependencies": {
+    "homebridge": "^2.0.0-beta.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds Homebridge v2.0 compatibility (`^1.8.0 || ^2.0.0-beta.0`)
- Replaces deprecated `request` + `q` + `lodash` with `axios` + `tough-cookie` (native Promises)
- Fixes removed `Characteristic.getValue()` API — replaced with `updateValue()`
- Fixes double-callback bug in `setState` and incorrect `latestData` path in `updateStatus`
- Adds `config.schema.json` for Homebridge UI support
- Updates CI to Node.js 18/20/22 and actions/checkout@v4
- Bumps minimum Node.js requirement to 18.15.0

## Breaking Changes

- Requires Node.js ≥ 18.15.0 (was `>=0.12.0`)
- Requires Homebridge ≥ 1.8.0 (was `>=0.4.16`)

## Test plan

- [ ] Push branch and confirm CI passes on Node 18/20/22
- [ ] Install on Homebridge, confirm login and device discovery succeed
- [ ] Confirm fan On/Off control works
- [ ] Confirm momentary mode switches (Auto/On/Circulate/Follow Schedule) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)